### PR TITLE
Switched order of outfit card entry to be first in leftside

### DIFF
--- a/cad/client/src/components/relatedComparison/OutfitCard.jsx
+++ b/cad/client/src/components/relatedComparison/OutfitCard.jsx
@@ -7,7 +7,7 @@ const OutfitCard = ({
 }) => {
   return (
     <div className='product-card-container'>
-      <button onClick={() => handleRemoveClick(id)} type='button' label='remove-item' className='action-item-btn'>
+      <button onClick={() => handleRemoveClick(id)} aria-label='remove-item-btn' type='button' label='remove-item' className='action-item-btn'>
         <i className='fa-solid fa-xmark' style={{ color: '#ffffff', margin: 'auto' }} />
       </button>
       <img className='product-card-img' src={photos?.url} alt='product-item-img' />

--- a/cad/client/src/components/relatedComparison/OutfitSection.jsx
+++ b/cad/client/src/components/relatedComparison/OutfitSection.jsx
@@ -26,7 +26,7 @@ const OutfitSection = () => {
     }
     const hasItem = outfitItems.some((item) => item.id === newItem.id);
     if (!hasItem) {
-      setOutfitItems((prevItems) => [...prevItems, newItem]);
+      setOutfitItems((prevItems) => [newItem, ...prevItems]);
     }
   };
 

--- a/cad/client/src/components/relatedComparison/RelatedCard.jsx
+++ b/cad/client/src/components/relatedComparison/RelatedCard.jsx
@@ -27,7 +27,7 @@ const RelatedCard = ({
   return (
     <>
       <div className='product-card-container related-product-card' id={id}>
-        <button onClick={() => handleCompareClick()} type='button' label='compare-item' className='action-item-btn'>
+        <button onClick={() => handleCompareClick()} aria-label='compare-item-btn' type='button' label='compare-item' className='action-item-btn'>
           <i className='fa-solid fa-star-sharp fa-xs' style={{ color: '#ffffff', padding: '3px' }} />
         </button>
         <div className='product-card-content' role='button' tabIndex={0} onKeyDown={handleItemClick} onClick={handleItemClick}>
@@ -57,9 +57,6 @@ const RelatedCard = ({
     </>
   );
 };
-
-// TODO: Consider moving this to a different component
-// TODO: Star count is incorrect
 
 function ComparsionModalContent({ onClose, currentProduct, selectedProduct }) {
   function formatComparedFeatures(currentProductFeatures = [], selectedProductFeatures = []) {

--- a/cad/client/src/components/relatedComparison/RelatedCard.jsx
+++ b/cad/client/src/components/relatedComparison/RelatedCard.jsx
@@ -30,7 +30,7 @@ const RelatedCard = ({
         <button onClick={() => handleCompareClick()} aria-label='compare-item-btn' type='button' label='compare-item' className='action-item-btn'>
           <i className='fa-solid fa-star-sharp fa-xs' style={{ color: '#ffffff', padding: '3px' }} />
         </button>
-        <div className='product-card-content' role='button' tabIndex={0} onKeyDown={handleItemClick} onClick={handleItemClick}>
+        <div className='product-card-content' role='button' aria-label='product-card-btn' tabIndex={0} onKeyDown={handleItemClick} onClick={handleItemClick}>
           <img className='product-card-img' src={photos?.url} alt='product-item-img' />
           <div className='product-card-details'>
             <h6>{category.toUpperCase()}</h6>


### PR DESCRIPTION
- Outfit cards now enter into outfit section left to right
- Added screen-reader labels to help with lighthouse scoring